### PR TITLE
feat!: add mango (maple) support for course creation assignment receiver

### DIFF
--- a/openedx_demo_plugin/receivers.py
+++ b/openedx_demo_plugin/receivers.py
@@ -31,7 +31,9 @@ def assign_org_course_access_to_user(user: UserData, **kwargs):
     """
     visitor_org_short_name = getattr(settings, "OPEN_EDX_VISITOR_ORG", None)
     if not visitor_org_short_name:
+        log.info("No OPEN_EDX_VISITOR_ORG provided, terminating course creation assignment.")
         return
+
     visitor_org = get_organization_by_short_name(visitor_org_short_name)
 
     registered_user = User.objects.get(username=user.pii.username)
@@ -40,6 +42,11 @@ def assign_org_course_access_to_user(user: UserData, **kwargs):
         state=CourseCreator.GRANTED,
         all_organizations=False,
     )
+
+    course_creator_admin_id = getattr(settings, "COURSE_CREATOR_ADMIN_ID", None)
+    if not course_creator_admin_id:
+        log.info("No COURSE_CREATOR_ADMIN_ID provided, terminating course creation assignment.")
+        return
 
     # In order to add course creator permissions programmatically, we must attach
     # to the user just registered. So the post_add signals receivers like

--- a/openedx_demo_plugin/receivers.py
+++ b/openedx_demo_plugin/receivers.py
@@ -52,7 +52,7 @@ def assign_org_course_access_to_user(user: UserData, **kwargs):
     # to the user just registered. So the post_add signals receivers like
     # `course_creator_organizations_changed_callback` can run checks over instance.admin.
     try:
-        course_creator.admin = User.objects.get(username=settings.COURSE_CREATOR_ADMIN_ID)
+        course_creator.admin = User.objects.get(username=course_creator_admin_id)
     except User.DoestNotExist:
         log.exception("User with username specified in COURSE_CREATOR_ADMIN_ID does not exist.")
         return

--- a/openedx_demo_plugin/settings/common.py
+++ b/openedx_demo_plugin/settings/common.py
@@ -24,3 +24,5 @@ def plugin_settings(settings):
             ]
         }
     }
+    if "cms.djangoapps.course_creators" not in settings.INSTALLED_APPS:
+        settings.INSTALLED_APPS = settings.INSTALLED_APPS + ["cms.djangoapps.course_creators"]

--- a/openedx_demo_plugin/tests/test_receivers.py
+++ b/openedx_demo_plugin/tests/test_receivers.py
@@ -5,6 +5,7 @@ Classes:
 """
 from unittest.mock import patch
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 from openedx_events.data import EventsMetadata
@@ -16,6 +17,9 @@ from openedx_demo_plugin.receivers import assign_org_course_access_to_user
 User = get_user_model()
 
 
+@override_settings(
+    OPEN_EDX_VISITOR_ORG="Public", COURSE_CREATOR_ADMIN_ID="dummy-staff-user",
+)
 class RegistrationCompletedReceiverTest(TestCase):
     """
     Tests the registration receiver assigns the correct permissions.
@@ -40,25 +44,80 @@ class RegistrationCompletedReceiverTest(TestCase):
             minorversion=0,
         )
         self.registered_user = User.objects.create(username=self.user.pii.username)
+        self.staff = User.objects.create(username=settings.COURSE_CREATOR_ADMIN_ID, is_staff=True)
 
-    @patch("openedx_demo_plugin.receivers.get_access_role_by_role_name")
-    def test_receiver_called_after_event(self, get_access_role_by_role_name):
+    @patch("openedx_demo_plugin.receivers.CourseCreator")
+    @patch("openedx_demo_plugin.receivers.get_organization_by_short_name")
+    def test_receiver_called_after_event(self, get_organization_by_short_name, course_creator):
         """
         Test that assign_org_course_access_to_user is called the correct information after sending
         STUDENT_REGISTRATION_COMPLETED event.
         """
-        org_content_creator_role = get_access_role_by_role_name("org_course_creator_group")
+        get_organization_by_short_name.return_value = {
+            "id": 1,
+        }
         STUDENT_REGISTRATION_COMPLETED.connect(assign_org_course_access_to_user)
 
         STUDENT_REGISTRATION_COMPLETED.send_event(
             user=self.user,
         )
 
-        org_content_creator_role(org="Public").add_users.assert_called_with(self.registered_user)
+        get_organization_by_short_name.assert_called_with(settings.OPEN_EDX_VISITOR_ORG)
+        course_creator.assert_called_with(
+            user=self.registered_user,
+            state=course_creator.GRANTED,
+            all_organizations=False,
+        )
+        course_creator.organizations.add.assert_called_with(settings.OPEN_EDX_VISITOR_ORG)
+
+    @override_settings(COURSE_CREATOR_ADMIN_ID="non-existent-user")
+    @patch("openedx_demo_plugin.receivers.CourseCreator")
+    @patch("openedx_demo_plugin.receivers.get_organization_by_short_name")
+    def test_unexistent_course_creator_staff(self, get_organization_by_short_name, course_creator):
+        """
+        Test that stops when the user associated with COURSE_CREATOR_ADMIN_ID does not exist
+        after sending STUDENT_REGISTRATION_COMPLETED event.
+        """
+        STUDENT_REGISTRATION_COMPLETED.connect(assign_org_course_access_to_user)
+
+        STUDENT_REGISTRATION_COMPLETED.send_event(
+            user=self.user,
+        )
+
+        get_organization_by_short_name.assert_called_with(settings.OPEN_EDX_VISITOR_ORG)
+        course_creator.assert_called_with(
+            user=self.registered_user,
+            state=course_creator.GRANTED,
+            all_organizations=False,
+        )
+        course_creator.organizations.add.assert_not_called()
+
+    @override_settings(COURSE_CREATOR_ADMIN_ID=None)
+    @patch("openedx_demo_plugin.receivers.CourseCreator")
+    @patch("openedx_demo_plugin.receivers.get_organization_by_short_name")
+    def test_not_specified_course_creator_id(self, get_organization_by_short_name, course_creator):
+        """
+        Test that stops when COURSE_CREATOR_ADMIN_ID is not specified before sending STUDENT_REGISTRATION_COMPLETED
+        event.
+        """
+        STUDENT_REGISTRATION_COMPLETED.connect(assign_org_course_access_to_user)
+
+        STUDENT_REGISTRATION_COMPLETED.send_event(
+            user=self.user,
+        )
+
+        get_organization_by_short_name.assert_called_with(settings.OPEN_EDX_VISITOR_ORG)
+        course_creator.assert_called_with(
+            user=self.registered_user,
+            state=course_creator.GRANTED,
+            all_organizations=False,
+        )
+        course_creator.organizations.add.assert_not_called()
 
     @override_settings(OPEN_EDX_VISITOR_ORG=None)
-    @patch("openedx_demo_plugin.receivers.get_access_role_by_role_name")
-    def test_receiver_noop(self, get_access_role_by_role_name):
+    @patch("openedx_demo_plugin.receivers.CourseCreator")
+    @patch("openedx_demo_plugin.receivers.get_organization_by_short_name")
+    def test_receiver_noop(self, get_organization_by_short_name, course_creator):
         """
         Test that when OPEN_EDX_VISITOR_ORG is not defined then the receiver acts as
         a noop.
@@ -69,4 +128,6 @@ class RegistrationCompletedReceiverTest(TestCase):
             user=self.user,
         )
 
-        get_access_role_by_role_name.return_value.assert_not_called()
+        get_organization_by_short_name.return_value.assert_not_called()
+        course_creator.assert_not_called()
+        course_creator.organizations.add.assert_not_called()

--- a/openedx_demo_plugin/tests/test_receivers.py
+++ b/openedx_demo_plugin/tests/test_receivers.py
@@ -107,12 +107,8 @@ class RegistrationCompletedReceiverTest(TestCase):
             user=self.user,
         )
 
-        get_organization_by_short_name.assert_called_with(settings.OPEN_EDX_VISITOR_ORG)
-        course_creator.assert_called_with(
-            user=self.registered_user,
-            state=course_creator.GRANTED,
-            all_organizations=False,
-        )
+        get_organization_by_short_name.assert_not_called()
+        course_creator.assert_not_called()
         course_creator.return_value.organizations.add.assert_not_called()
 
     @override_settings(OPEN_EDX_VISITOR_ORG=None)

--- a/openedx_demo_plugin/tests/test_receivers.py
+++ b/openedx_demo_plugin/tests/test_receivers.py
@@ -53,8 +53,9 @@ class RegistrationCompletedReceiverTest(TestCase):
         Test that assign_org_course_access_to_user is called the correct information after sending
         STUDENT_REGISTRATION_COMPLETED event.
         """
+        organization_id = 1
         get_organization_by_short_name.return_value = {
-            "id": 1,
+            "id": organization_id,
         }
         STUDENT_REGISTRATION_COMPLETED.connect(assign_org_course_access_to_user)
 
@@ -68,7 +69,7 @@ class RegistrationCompletedReceiverTest(TestCase):
             state=course_creator.GRANTED,
             all_organizations=False,
         )
-        course_creator.organizations.add.assert_called_with(settings.OPEN_EDX_VISITOR_ORG)
+        course_creator.organizations.add.assert_called_with(organization_id)
 
     @override_settings(COURSE_CREATOR_ADMIN_ID="non-existent-user")
     @patch("openedx_demo_plugin.receivers.CourseCreator")

--- a/openedx_demo_plugin/tests/test_receivers.py
+++ b/openedx_demo_plugin/tests/test_receivers.py
@@ -69,7 +69,7 @@ class RegistrationCompletedReceiverTest(TestCase):
             state=course_creator.GRANTED,
             all_organizations=False,
         )
-        course_creator.organizations.add.assert_called_with(organization_id)
+        course_creator.return_value.organizations.add.assert_called_with(organization_id)
 
     @override_settings(COURSE_CREATOR_ADMIN_ID="non-existent-user")
     @patch("openedx_demo_plugin.receivers.CourseCreator")
@@ -91,7 +91,7 @@ class RegistrationCompletedReceiverTest(TestCase):
             state=course_creator.GRANTED,
             all_organizations=False,
         )
-        course_creator.organizations.add.assert_not_called()
+        course_creator.return_value.organizations.add.assert_not_called()
 
     @override_settings(COURSE_CREATOR_ADMIN_ID=None)
     @patch("openedx_demo_plugin.receivers.CourseCreator")
@@ -113,7 +113,7 @@ class RegistrationCompletedReceiverTest(TestCase):
             state=course_creator.GRANTED,
             all_organizations=False,
         )
-        course_creator.organizations.add.assert_not_called()
+        course_creator.return_value.organizations.add.assert_not_called()
 
     @override_settings(OPEN_EDX_VISITOR_ORG=None)
     @patch("openedx_demo_plugin.receivers.CourseCreator")
@@ -131,4 +131,4 @@ class RegistrationCompletedReceiverTest(TestCase):
 
         get_organization_by_short_name.return_value.assert_not_called()
         course_creator.assert_not_called()
-        course_creator.organizations.add.assert_not_called()
+        course_creator.return_value.organizations.add.assert_not_called()


### PR DESCRIPTION
**Description:** 
This PR adds support for our maple fork, since the issue BC-14 is not available in that version. 

Previously, we'd implemented the automatic permissions assignment based on the customization [BC-14](https://github.com/eduNEXT/edunext-platform/pull/574) that was implemented in our lilac fork. Now, we're making it compatible with maple using the course creator model. 

**Installation instructions:** 
```
pip install -e git+https://github.com/eduNEXT/openedx-demo-plugin@MJG/mango-support#egg=openedx_demo_plugin==0.2.0
```

**Testing instructions:**

1. After installing the plugin, you must configure a staff users username to be used throughout the assignment:
`"COURSE_CREATOR_ADMIN_ID": "dummy-admin"`
2. Create a user in the LMS
3. Check with staff permissions the LMS/CMS django admin, the following should exist:
Course access role (LMS)
![image](https://user-images.githubusercontent.com/64440265/191595503-094c9b6d-1f6d-4bdd-b1bc-aef3d8337496.png)
Course creator role (CMS)
![image](https://user-images.githubusercontent.com/64440265/191595568-a42f60ff-01d1-4fac-965a-34865799a3e6.png)
![image](https://user-images.githubusercontent.com/64440265/191595680-8b8ca3f9-f283-4634-9373-c42b7b7fd2b8.png)
Both `org_content_creator_role` & course creator are created since adding an organization to a current course creator creates a role in the access roles table.
4. Now, using the brand new user login to Studio. You must be able to create courses just in the  `OPEN_EDX_VISITOR_ORG`

**Reviewers:**
- [ ] @felipemontoya 
- [ ] @eduNEXT/service-delivery 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
